### PR TITLE
Add support for custom server path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ window.$docsify = {
 </script>
 ```
 
+## serverPath
+By default, the official PlantUML server is used. If you have your own, configure it using the `serverPath` option:
+
+```
+<script>
+window.$docsify = {
+  plantuml: {
+    serverPath: 'https://custom-server.local/plantuml/png/',
+  },
+}
+</script>
+```
 
 ## Example
 - [index.html](example/index.html)

--- a/src/plantuml.js
+++ b/src/plantuml.js
@@ -6,7 +6,7 @@ var SELECTOR = 'pre[data-lang="' + LANG + '"]'
 
 export function plant (content, config) {
   content = skin(config.skin) + content
-  return '<img src="http://www.plantuml.com/plantuml/svg/' + encode(content) + '" />'
+  return '<img src="' + (config.serverPath || 'http://www.plantuml.com/plantuml/svg/') + encode(content) + '" />'
 }
 
 export function replace (content, selector, config) {


### PR DESCRIPTION
Adds a `serverPath` config option for specifying a custom PlantUML server URL.